### PR TITLE
Fix users table column mismatch: full_name → name

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -81,7 +81,7 @@ export async function GET(request: NextRequest) {
   const upsertPayload: Database["public"]["Tables"]["users"]["Insert"] = {
     id: user.id,
     email,
-    full_name: name,
+    name,
     updated_at: new Date().toISOString(),
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -98,7 +98,7 @@ export interface Database {
         Row: {
           id: string;
           email: string;
-          full_name: string | null;
+          name: string | null;
           avatar_url: string | null;
           interest_tags: string[];
           created_at: string;
@@ -107,7 +107,7 @@ export interface Database {
         Insert: {
           id?: string;
           email: string;
-          full_name?: string | null;
+          name?: string | null;
           avatar_url?: string | null;
           interest_tags?: string[];
           created_at?: string;
@@ -116,7 +116,7 @@ export interface Database {
         Update: {
           id?: string;
           email?: string;
-          full_name?: string | null;
+          name?: string | null;
           avatar_url?: string | null;
           interest_tags?: string[];
           created_at?: string;


### PR DESCRIPTION
The DB users table has a `name` column but the codebase referenced `full_name`. This caused the auth callback upsert to silently fail, meaning new users were authenticated but never inserted into the public.users table — breaking recommendations and profile pages.

- Update users Row/Insert/Update types in supabase/types.ts
- Fix auth callback upsert payload to use `name` field