### PR TITLE
solved bulk status api flip for non-pending events #128

### DIFF
--- a/docs/plans/2026-02-26-bulk-actions-admin.md
+++ b/docs/plans/2026-02-26-bulk-actions-admin.md
@@ -1,0 +1,192 @@
+# PR: Bulk Select + Approve/Reject for Admin Pending Queue
+
+**Branch:** `128-bulk-actions-admin`  
+**Date:** 2026-02-26  
+**Closes:** #128
+
+---
+
+## Summary
+
+The admin pending queue previously handled events one at a time. This PR adds bulk selection with shared approve/reject actions to reduce the time admins spend processing a backlog of pending events.
+
+---
+
+## Files Changed
+
+| File                                            | Change                                                                          |
+| ----------------------------------------------- | ------------------------------------------------------------------------------- |
+| `src/app/api/admin/events/bulk-status/route.ts` | **New** — `POST /api/admin/events/bulk-status` endpoint                         |
+| `src/app/admin/pending/page.tsx`                | **Modified** — bulk selection UI, toolbar, shared reject dialog, error feedback |
+
+---
+
+## Feature Breakdown
+
+### 1. `POST /api/admin/events/bulk-status`
+
+Accepts an array of event IDs and a target status, performs a single batched Supabase `.update().in().eq()` query, then fires individual notifications to each event creator (best-effort).
+
+**Request body**
+
+```json
+{
+  "ids": ["uuid-1", "uuid-2"],
+  "status": "approved" | "rejected",
+  "reason": "string (required when status = rejected)"
+}
+```
+
+**Responses**
+| Status | Body | Condition |
+|---|---|---|
+| `200` | `{ success: true, count: N }` | All matching events updated |
+| `400` | `{ error: "Invalid JSON body" }` | Malformed request body |
+| `400` | `{ error: "ids must be a non-empty array" }` | `ids` missing, not an array, or empty |
+| `400` | `{ error: "Invalid status" }` | `status` not `approved` or `rejected` |
+| `400` | `{ error: "A rejection reason is required" }` | `status = rejected` with no/whitespace reason |
+| `403` | `{ error: "Forbidden" }` | Caller is not an admin |
+| `500` | `{ error: "..." }` | Supabase error |
+
+### 2. Checkboxes on each pending event card
+
+- Native `<input type="checkbox">` rendered at the top-left of each card header
+- `aria-label="Select {event.title}"` for screen-reader accessibility
+- Selected cards are highlighted with `ring-2 ring-primary`
+- Card body content is offset with `pl-10` so text alignment is unchanged regardless of checkbox presence
+
+### 3. Select All checkbox in the toolbar
+
+- Renders an indeterminate state (`el.indeterminate = true`) via a `ref` callback when some — but not all — events are checked
+- Clicking while indeterminate selects all
+- Clicking while all are selected deselects all
+
+### 4. Selection count display
+
+- `{n} selected` text appears in the toolbar whenever at least one event is checked
+- Count updates immediately on every individual toggle or Select All toggle
+
+### 5. Bulk Approve
+
+- **Approve Selected** button is disabled when `selectedIds.size === 0` or a request is in flight
+- Takes a snapshot of `selectedIds` at call time to avoid any closure staleness if state changes mid-request
+- Calls `POST /api/admin/events/bulk-status` with `status: "approved"`
+- On success: removes all approved events from the local list and clears `selectedIds`
+- On failure (non-2xx or network error): shows an error banner; list is unchanged
+
+### 6. Bulk Reject with shared reason dialog
+
+- **Reject Selected** button opens a modal dialog
+- Dialog title shows `Reject N event(s)` for bulk, or `Reject event` for single-card reject
+- **Confirm Rejection** button is disabled until the reason textarea contains at least one non-whitespace character
+- Pressing Cancel or closing via the backdrop/ESC correctly resets `rejectReason` to `""` (fixed via `onOpenChange`)
+- On submit: reason is passed to `POST /api/admin/events/bulk-status`
+- The same dialog is reused for single-card reject (routes to the existing `PATCH /api/admin/events/[id]/status`)
+- `rejectReason` and `rejectTarget` are captured into local variables before closing the dialog, preventing closure stale-state issues during the async request
+
+### 7. Error feedback
+
+- `actionError` state holds the most recent error string
+- Displayed in a dismissible banner between the page header and the toolbar
+- Set on both non-OK responses (parses `error` field from JSON body) and `catch` blocks (network errors)
+- Cleared at the start of every new action attempt
+
+---
+
+## Edge Cases Addressed
+
+### API layer
+
+| Scenario                                             | Handling                                                                                                |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Malformed JSON body                                  | `request.json()` wrapped in try/catch → `400 Invalid JSON body`                                         |
+| `ids` is not an array                                | `!Array.isArray(ids)` check → `400`                                                                     |
+| `ids` is an empty array                              | `ids.length === 0` check → `400`                                                                        |
+| `status` is any arbitrary string                     | allowlist check → `400`                                                                                 |
+| `status = "rejected"` with whitespace-only reason    | `reason?.trim()` falsy check → `400`                                                                    |
+| IDs that have already been actioned by another admin | `.eq("status", "pending")` filter prevents double-processing; Supabase silently skips non-matching rows |
+| Some IDs do not exist in the database                | Supabase `.in()` with non-existent IDs is a no-op; no error thrown                                      |
+| Notification failure                                 | Wrapped in its own `try/catch`; a notification error does not roll back the status update               |
+| Non-admin caller                                     | `verifyAdmin()` guard → `403`                                                                           |
+
+### Frontend — selection
+
+| Scenario                                                                                            | Handling                                                                                                          |
+| --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Select All then single-card approve                                                                 | Event is removed from both `events` and `selectedIds`; `allSelected` and `someSelected` recompute correctly       |
+| Single-card approve while others are selected                                                       | Only that event is removed from `events` and `selectedIds`; other selections preserved                            |
+| All remaining events approved/rejected individually                                                 | `events` becomes empty → empty state renders; toolbar and cards unmount; `selectedIds` is cleared in each handler |
+| `selectedIds` contains IDs no longer in `events` (stale list from another admin acting in parallel) | API silently ignores them (`.eq("status", "pending")` guard); local filter removes them from the view on success  |
+| Clicking Select All when indeterminate                                                              | Selects all (matches expected UX convention)                                                                      |
+
+### Frontend — bulk actions
+
+| Scenario                                                     | Handling                                                                                                                                                  |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `handleBulkApprove` called with 0 selections                 | Early return guard; buttons also disabled at the UI level                                                                                                 |
+| User changes selection while request is in flight            | `snapshot` captures `selectedIds` at call time; subsequent state changes don't affect which IDs are cleared                                               |
+| Bulk action returns non-2xx                                  | Error banner shown; list unchanged; loading spinner dismissed                                                                                             |
+| Network error during bulk action                             | `catch` block sets error banner; `finally` resets `bulkActionLoading`                                                                                     |
+| Clicking Approve Selected and Reject Selected simultaneously | `bulkActionLoading = true` disables both buttons for the duration of the request; single-card buttons are also disabled while `bulkActionLoading` is true |
+
+### Frontend — reject dialog
+
+| Scenario                                                        | Handling                                                                                                           |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Closing dialog via backdrop or ESC key                          | `onOpenChange(false)` triggers `setRejectReason("")`; stale reason cannot leak into next open                      |
+| Clicking Cancel button                                          | Explicitly resets both `rejectDialogOpen` and `rejectReason`                                                       |
+| Submitting with only whitespace in reason                       | **Confirm** button is disabled (`!rejectReason.trim()`); also enforced server-side                                 |
+| Opening single-card reject while bulk reject dialog is building | Impossible — modal overlay blocks card interactions while dialog is open                                           |
+| Rejection request fails after dialog is closed                  | Error banner appears on the page; dialog does not reopen (admin can retry via the card button)                     |
+| Very long rejection reason                                      | `textarea` is `resize-none`; no server-side character limit currently enforced (future: add max-length validation) |
+
+---
+
+## Testing Checklist
+
+### Bulk approve
+
+- [ ] Select 2+ events → **Approve Selected** removes all from list and clears checkboxes
+- [ ] **Approve Selected** is disabled with 0 selections
+- [ ] Creators receive `event_approved` notifications
+
+### Bulk reject
+
+- [ ] Select 2+ events → **Reject Selected** opens dialog with correct count in title
+- [ ] **Confirm Rejection** disabled until at least one non-whitespace character is typed
+- [ ] Submitting rejects all selected events and clears the list
+- [ ] Creators receive `event_rejected` notifications containing the shared reason
+- [ ] Closing dialog via ESC/backdrop clears the textarea; reopening shows an empty reason field
+
+### Single-card actions
+
+- [ ] Per-card **Approve** still works with no selections active
+- [ ] Per-card **Reject** opens the same dialog; submission rejects only that event
+- [ ] Single-card buttons are disabled during an in-flight bulk request (`bulkActionLoading`)
+
+### Select All
+
+- [ ] Checking Select All selects every card (ring visible on all)
+- [ ] Unchecking Select All deselects all cards
+- [ ] Partially selected state shows indeterminate checkbox
+- [ ] Approving/rejecting individual events while all are selected correctly updates the Select All state
+
+### Error handling
+
+- [ ] Simulate 500 from API (e.g., kill DB connection) → error banner appears; list unchanged
+- [ ] Simulate offline → error banner shows network error message
+- [ ] Dismissing the banner clears it; running the same action again resets it
+
+### Accessibility
+
+- [ ] Each per-card checkbox has a descriptive `aria-label`
+- [ ] Reject reason `<textarea>` is associated with its `<label>` via `htmlFor`/`id`
+- [ ] All buttons have visible focus rings
+
+---
+
+## Known Limitations
+
+- The `count` field in the bulk-status response reflects `ids.length`, not the number of DB rows actually updated (Supabase does not return update counts by default). If some IDs were already non-pending, the true count will be lower than reported.
+- No per-event character limit is enforced on rejection reasons.
+- The pending list is not auto-refreshed; if two admins are reviewing simultaneously, one may see stale cards until they reload. The `.eq("status", "pending")` API guard prevents double-processing, but the UI will show a silent no-op rather than a meaningful conflict message.

--- a/src/app/admin/pending/page.tsx
+++ b/src/app/admin/pending/page.tsx
@@ -5,6 +5,13 @@ import { createClient } from "@/lib/supabase/client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
 import { CheckCircle, XCircle, Calendar, MapPin } from "lucide-react";
 
 interface PendingEvent {
@@ -25,6 +32,18 @@ export default function PendingEventsPage() {
   const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
 
+  // Bulk selection
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [bulkActionLoading, setBulkActionLoading] = useState(false);
+
+  // Action error feedback
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  // Bulk reject dialog
+  const [rejectDialogOpen, setRejectDialogOpen] = useState(false);
+  const [rejectReason, setRejectReason] = useState("");
+  const [rejectTarget, setRejectTarget] = useState<"bulk" | string>("bulk");
+
   const fetchPending = useCallback(async () => {
     const supabase = createClient();
     const { data } = await supabase
@@ -41,8 +60,18 @@ export default function PendingEventsPage() {
     fetchPending();
   }, [fetchPending]);
 
+  // ── Single-event actions ────────────────────────────────────────────────────
+
   const handleAction = async (eventId: string, status: "approved" | "rejected") => {
+    if (status === "rejected") {
+      setRejectTarget(eventId);
+      setRejectReason("");
+      setRejectDialogOpen(true);
+      return;
+    }
+
     setActionLoading(eventId);
+    setActionError(null);
     try {
       const res = await fetch(`/api/admin/events/${eventId}/status`, {
         method: "PATCH",
@@ -52,11 +81,139 @@ export default function PendingEventsPage() {
 
       if (res.ok) {
         setEvents((prev) => prev.filter((e) => e.id !== eventId));
+        setSelectedIds((prev) => {
+          const next = new Set(prev);
+          next.delete(eventId);
+          return next;
+        });
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setActionError(data.error ?? "Action failed. Please try again.");
       }
+    } catch {
+      setActionError("Network error. Please check your connection.");
     } finally {
       setActionLoading(null);
     }
   };
+
+  // ── Selection helpers ───────────────────────────────────────────────────────
+
+  const allSelected = events.length > 0 && selectedIds.size === events.length;
+  const someSelected = selectedIds.size > 0 && !allSelected;
+
+  const toggleSelectAll = () => {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(events.map((e) => e.id)));
+    }
+  };
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  // ── Bulk approve ────────────────────────────────────────────────────────────
+
+  const handleBulkApprove = async () => {
+    if (selectedIds.size === 0) return;
+    setBulkActionLoading(true);
+    setActionError(null);
+    const snapshot = new Set(selectedIds);
+    try {
+      const ids = Array.from(snapshot);
+      const res = await fetch("/api/admin/events/bulk-status", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ids, status: "approved" }),
+      });
+
+      if (res.ok) {
+        setEvents((prev) => prev.filter((e) => !snapshot.has(e.id)));
+        setSelectedIds(new Set());
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setActionError(data.error ?? "Bulk approve failed. Please try again.");
+      }
+    } catch {
+      setActionError("Network error. Please check your connection.");
+    } finally {
+      setBulkActionLoading(false);
+    }
+  };
+
+  // ── Reject dialog confirm ───────────────────────────────────────────────────
+
+  const handleRejectConfirm = async () => {
+    if (!rejectReason.trim()) return;
+
+    if (rejectTarget === "bulk") {
+      const snapshot = new Set(selectedIds);
+      const capturedReason = rejectReason;
+      setBulkActionLoading(true);
+      setRejectDialogOpen(false);
+      setRejectReason("");
+      setActionError(null);
+      try {
+        const ids = Array.from(snapshot);
+        const res = await fetch("/api/admin/events/bulk-status", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids, status: "rejected", reason: capturedReason }),
+        });
+
+        if (res.ok) {
+          setEvents((prev) => prev.filter((e) => !snapshot.has(e.id)));
+          setSelectedIds(new Set());
+        } else {
+          const data = await res.json().catch(() => ({}));
+          setActionError(data.error ?? "Bulk rejection failed. Please try again.");
+        }
+      } catch {
+        setActionError("Network error. Please check your connection.");
+      } finally {
+        setBulkActionLoading(false);
+      }
+    } else {
+      const eventId = rejectTarget;
+      const capturedReason = rejectReason;
+      setActionLoading(eventId);
+      setRejectDialogOpen(false);
+      setRejectReason("");
+      setActionError(null);
+      try {
+        const res = await fetch(`/api/admin/events/${eventId}/status`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "rejected", reason: capturedReason }),
+        });
+
+        if (res.ok) {
+          setEvents((prev) => prev.filter((e) => e.id !== eventId));
+          setSelectedIds((prev) => {
+            const next = new Set(prev);
+            next.delete(eventId);
+            return next;
+          });
+        } else {
+          const data = await res.json().catch(() => ({}));
+          setActionError(data.error ?? "Rejection failed. Please try again.");
+        }
+      } catch {
+        setActionError("Network error. Please check your connection.");
+      } finally {
+        setActionLoading(null);
+      }
+    }
+  };
+
+  // ── Render ──────────────────────────────────────────────────────────────────
 
   if (loading) {
     return (
@@ -69,79 +226,216 @@ export default function PendingEventsPage() {
 
   return (
     <div className="space-y-6">
+      {/* ── Page header ── */}
       <div className="flex items-center justify-between">
         <h2 className="text-2xl font-semibold">Pending Events</h2>
         <Badge variant="secondary">{events.length} pending</Badge>
       </div>
+
+      {/* ── Error banner ── */}
+      {actionError && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          {actionError}
+          <button
+            className="ml-3 underline"
+            onClick={() => setActionError(null)}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
 
       {events.length === 0 ? (
         <div className="text-center py-12 text-muted-foreground">
           <p>No pending events at this time.</p>
         </div>
       ) : (
-        <div className="space-y-4">
-          {events.map((event) => (
-            <Card key={event.id}>
-              <CardHeader>
-                <div className="flex items-start justify-between">
-                  <div>
-                    <CardTitle className="text-lg">{event.title}</CardTitle>
-                    <p className="text-sm text-muted-foreground mt-1">
-                      {event.organizer ?? "Unknown organizer"}
-                    </p>
-                  </div>
-                  <Badge variant="outline">Pending</Badge>
-                </div>
-              </CardHeader>
-              <CardContent>
-                {event.description && (
-                  <p className="text-sm mb-3 line-clamp-3">{event.description}</p>
-                )}
-                <div className="flex flex-wrap gap-4 text-sm text-muted-foreground mb-4">
-                  <span className="flex items-center gap-1">
-                    <Calendar className="h-3.5 w-3.5" />
-                    {new Date(event.start_date).toLocaleDateString()}
-                  </span>
-                  {event.location && (
-                    <span className="flex items-center gap-1">
-                      <MapPin className="h-3.5 w-3.5" />
-                      {event.location}
-                    </span>
-                  )}
-                </div>
-                {event.tags && event.tags.length > 0 && (
-                  <div className="flex flex-wrap gap-1 mb-4">
-                    {event.tags.map((tag) => (
-                      <Badge key={tag} variant="secondary" className="text-xs">
-                        {tag}
-                      </Badge>
-                    ))}
-                  </div>
-                )}
-                <div className="flex gap-2">
-                  <Button
-                    size="sm"
-                    onClick={() => handleAction(event.id, "approved")}
-                    disabled={actionLoading === event.id}
-                  >
-                    <CheckCircle className="mr-2 h-4 w-4" />
-                    Approve
-                  </Button>
-                  <Button
-                    variant="destructive"
-                    size="sm"
-                    onClick={() => handleAction(event.id, "rejected")}
-                    disabled={actionLoading === event.id}
-                  >
-                    <XCircle className="mr-2 h-4 w-4" />
-                    Reject
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+        <>
+          {/* ── Bulk action toolbar ── */}
+          <div className="flex items-center gap-4 rounded-lg border bg-muted/40 px-4 py-3">
+            {/* Select all */}
+            <label className="flex items-center gap-2 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={allSelected}
+                ref={(el) => {
+                  if (el) el.indeterminate = someSelected;
+                }}
+                onChange={toggleSelectAll}
+                className="h-4 w-4 rounded border-gray-300 accent-primary cursor-pointer"
+              />
+              <span className="text-sm font-medium">Select all</span>
+            </label>
+
+            {/* Selection count */}
+            {selectedIds.size > 0 && (
+              <span className="text-sm text-muted-foreground">
+                {selectedIds.size} selected
+              </span>
+            )}
+
+            {/* Bulk actions */}
+            <div className="ml-auto flex gap-2">
+              <Button
+                size="sm"
+                disabled={selectedIds.size === 0 || bulkActionLoading}
+                onClick={handleBulkApprove}
+              >
+                <CheckCircle className="mr-2 h-4 w-4" />
+                Approve Selected
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={selectedIds.size === 0 || bulkActionLoading}
+                onClick={() => {
+                  setRejectTarget("bulk");
+                  setRejectReason("");
+                  setRejectDialogOpen(true);
+                }}
+              >
+                <XCircle className="mr-2 h-4 w-4" />
+                Reject Selected
+              </Button>
+            </div>
+          </div>
+
+          {/* ── Event cards ── */}
+          <div className="space-y-4">
+            {events.map((event) => {
+              const isSelected = selectedIds.has(event.id);
+              return (
+                <Card
+                  key={event.id}
+                  className={isSelected ? "ring-2 ring-primary" : undefined}
+                >
+                  <CardHeader>
+                    <div className="flex items-start gap-3">
+                      {/* Per-card checkbox */}
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={() => toggleSelect(event.id)}
+                        className="mt-1 h-4 w-4 rounded border-gray-300 accent-primary cursor-pointer flex-shrink-0"
+                        aria-label={`Select ${event.title}`}
+                      />
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-start justify-between gap-2">
+                          <div>
+                            <CardTitle className="text-lg">{event.title}</CardTitle>
+                            <p className="text-sm text-muted-foreground mt-1">
+                              {event.organizer ?? "Unknown organizer"}
+                            </p>
+                          </div>
+                          <Badge variant="outline" className="flex-shrink-0">Pending</Badge>
+                        </div>
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="pl-10">
+                    {event.description && (
+                      <p className="text-sm mb-3 line-clamp-3">{event.description}</p>
+                    )}
+                    <div className="flex flex-wrap gap-4 text-sm text-muted-foreground mb-4">
+                      <span className="flex items-center gap-1">
+                        <Calendar className="h-3.5 w-3.5" />
+                        {new Date(event.start_date).toLocaleDateString()}
+                      </span>
+                      {event.location && (
+                        <span className="flex items-center gap-1">
+                          <MapPin className="h-3.5 w-3.5" />
+                          {event.location}
+                        </span>
+                      )}
+                    </div>
+                    {event.tags && event.tags.length > 0 && (
+                      <div className="flex flex-wrap gap-1 mb-4">
+                        {event.tags.map((tag) => (
+                          <Badge key={tag} variant="secondary" className="text-xs">
+                            {tag}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
+                    <div className="flex gap-2">
+                      <Button
+                        size="sm"
+                        onClick={() => handleAction(event.id, "approved")}
+                        disabled={actionLoading === event.id || bulkActionLoading}
+                      >
+                        <CheckCircle className="mr-2 h-4 w-4" />
+                        Approve
+                      </Button>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => handleAction(event.id, "rejected")}
+                        disabled={actionLoading === event.id || bulkActionLoading}
+                      >
+                        <XCircle className="mr-2 h-4 w-4" />
+                        Reject
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </>
       )}
+
+      {/* ── Reject reason dialog ── */}
+      <Dialog
+        open={rejectDialogOpen}
+        onOpenChange={(open) => {
+          setRejectDialogOpen(open);
+          if (!open) setRejectReason("");
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {rejectTarget === "bulk"
+                ? `Reject ${selectedIds.size} event${selectedIds.size !== 1 ? "s" : ""}`
+                : "Reject event"}
+            </DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="reject-reason">
+              Reason <span className="text-destructive">*</span>
+            </label>
+            <textarea
+              id="reject-reason"
+              rows={4}
+              placeholder="Provide a reason that will be shared with the organiser(s)…"
+              value={rejectReason}
+              onChange={(e) => setRejectReason(e.target.value)}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 resize-none"
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setRejectDialogOpen(false);
+                setRejectReason("");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={!rejectReason.trim()}
+              onClick={handleRejectConfirm}
+            >
+              <XCircle className="mr-2 h-4 w-4" />
+              Confirm Rejection
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/app/api/admin/events/bulk-status/route.ts
+++ b/src/app/api/admin/events/bulk-status/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { verifyAdmin } from "@/lib/admin";
+import { createServiceClient } from "@/lib/supabase/service";
+
+export async function POST(request: NextRequest) {
+  const { supabase, isAdmin } = await verifyAdmin();
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  let body: { ids?: unknown; status?: unknown; reason?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { ids, status, reason } = body as {
+    ids: string[];
+    status: "approved" | "rejected";
+    reason?: string;
+  };
+
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return NextResponse.json({ error: "ids must be a non-empty array" }, { status: 400 });
+  }
+
+  if (!["approved", "rejected"].includes(status)) {
+    return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+  }
+
+  if (status === "rejected" && !reason?.trim()) {
+    return NextResponse.json({ error: "A rejection reason is required" }, { status: 400 });
+  }
+
+  // Only touch events that are still pending — prevents accidentally
+  // re-processing events another admin already acted on in parallel.
+  const { error } = await supabase
+    .from("events")
+    .update({ status, updated_at: new Date().toISOString() })
+    .in("id", ids)
+    .eq("status", "pending");
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // Fire notifications for each event (best-effort)
+  try {
+    const serviceClient = createServiceClient();
+    const { data: events } = await serviceClient
+      .from("events")
+      .select("id, title, created_by")
+      .in("id", ids);
+
+    if (events && events.length > 0) {
+      const isApproved = status === "approved";
+      const notifications = events
+        .filter((e) => e.created_by)
+        .map((e) => ({
+          user_id: e.created_by as string,
+          type: isApproved ? "event_approved" : "event_rejected",
+          title: isApproved ? "Event Approved!" : "Event Not Approved",
+          message: isApproved
+            ? `Your event "${e.title}" has been approved and is now live.`
+            : `Your event "${e.title}" was not approved${reason ? `: ${reason}` : "."}`,
+          event_id: e.id,
+        }));
+
+      if (notifications.length > 0) {
+        await serviceClient.from("notifications").insert(notifications);
+      }
+    }
+  } catch (notifErr) {
+    console.error("[Admin] Failed to send bulk notifications:", notifErr);
+  }
+
+  return NextResponse.json({ success: true, count: ids.length });
+}


### PR DESCRIPTION
## Bulk select + approve/reject for admin pending queue

Closes #128

Adds batch moderation to `/admin/pending` so admins can action multiple events at once.

### What's new
- Checkbox on each event card + **Select All** (with indeterminate state)
- Live `{n} selected` count in the toolbar
- **Approve Selected** — single batched API call for all checked events
- **Reject Selected** — shared reason dialog; confirm disabled until reason is non-empty; same dialog reused for single-card reject
- Dismissible error banner on any API or network failure
- New `POST /api/admin/events/bulk-status` — batched update with admin guard, JSON validation, `.eq("status", "pending")` filter to prevent double-processing, per-creator notifications

### Files changed
- `src/app/api/admin/events/bulk-status/route.ts` *(new)*
- `src/app/admin/pending/page.tsx` *(modified)*

### How to test
1. Go to `/admin/pending` with a few pending events
2. Select multiple → **Approve Selected** → verify events disappear and creators get notified
3. Select multiple → **Reject Selected** → enter a reason → confirm → verify same
4. Per-card **Approve** / **Reject** should still work independently

### Known limitations
- `count` in the response reflects `ids.length`, not actual rows updated (Supabase doesn't return update counts)
- No character limit on rejection reasons yet
- List is not auto-refreshed; concurrent admins will see stale cards until reload (double-processing is prevented server-side)