### PR TITLE
email idem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -139,6 +139,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -706,7 +707,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
       "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
       }
@@ -715,15 +715,13 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@emotion/unitless": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
       "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
@@ -3198,6 +3196,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.81.1.tgz",
       "integrity": "sha512-KSdY7xb2L0DlLmlYzIOghdw/na4gsMcqJ8u4sD6tOQJr+x3hLujU9s4R8N3ob84/1bkvpvlU5PYKa1ae+OICnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.81.1",
         "@supabase/functions-js": "2.81.1",
@@ -3750,18 +3749,6 @@
         }
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/tree-sitter": {
-      "version": "0.22.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
-      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-addon-api": "^8.3.0",
-        "node-gyp-build": "^4.8.4"
-      }
-    },
     "node_modules/@swagger-api/apidom-reference": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.3.0.tgz",
@@ -4039,6 +4026,7 @@
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4050,6 +4038,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4065,8 +4054,7 @@
       "version": "4.2.7",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
       "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/swagger-jsdoc": {
       "version": "6.0.4",
@@ -4175,6 +4163,7 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -4682,6 +4671,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5304,6 +5294,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -5459,7 +5450,6 @@
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
       "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5864,7 +5854,6 @@
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
       "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -5874,7 +5863,6 @@
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
       "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -6203,7 +6191,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -6463,6 +6452,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6648,6 +6638,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7861,6 +7852,7 @@
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
       "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8566,6 +8558,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -9168,6 +9161,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -10675,6 +10669,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10990,6 +10985,7 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -11038,6 +11034,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11076,6 +11073,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11326,7 +11324,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-immutable": {
       "version": "4.0.0",
@@ -11759,8 +11758,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -12390,7 +12388,6 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.8.tgz",
       "integrity": "sha512-Kq/W41AKQloOqKM39zfaMdJ4BcYDw/N5CIq4/GTI0YjU6pKcZ1KKhk6b4du0a+6RA9pIfOP/eu94Ge7cu+PDCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "@emotion/unitless": "0.10.0",
@@ -12438,7 +12435,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -12475,8 +12471,7 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.0",
@@ -12757,6 +12752,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
       "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -12919,6 +12915,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13256,6 +13253,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13829,23 +13827,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yaml-ast-parser": {
       "version": "0.0.43",
       "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
@@ -13975,6 +13956,7 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/api/cron/send-reminders/route.ts
+++ b/src/app/api/cron/send-reminders/route.ts
@@ -11,70 +11,142 @@ export async function POST(request: NextRequest) {
 
   const supabase = createServiceClient();
   const now = new Date();
-  let remindersSent = { "24h": 0, "1h": 0 };
+  const remindersSent: Record<string, number> = { "24h": 0, "1h": 0 };
+  const remindersSkipped: Record<string, number> = { "24h": 0, "1h": 0 };
 
   try {
-    // 24-hour reminders: events starting between now+23h and now+25h
+    // ── 24-hour reminders ──────────────────────────────────────────────────
     const h24Start = new Date(now.getTime() + 23 * 60 * 60 * 1000).toISOString();
-    const h24End = new Date(now.getTime() + 25 * 60 * 60 * 1000).toISOString();
+    const h24End   = new Date(now.getTime() + 25 * 60 * 60 * 1000).toISOString();
 
-    const { data: saved24h } = await supabase
-      .from("saved_events")
-      .select("user_id, event_id, events:event_id(id, title, start_date)")
-      .gte("events.start_date", h24Start)
-      .lte("events.start_date", h24End);
+    // Step 1: find events in the 24h window
+    const { data: events24h } = await supabase
+      .from("events")
+      .select("id, title, start_date")
+      .gte("start_date", h24Start)
+      .lte("start_date", h24End);
 
-    if (saved24h) {
-      for (const row of saved24h) {
-        const event = row.events as unknown as { id: string; title: string; start_date: string } | null;
-        if (!event) continue;
+    if (events24h && events24h.length > 0) {
+      const eventIds24h = events24h.map((e) => e.id);
 
-        const { error: err24h } = await supabase.from("notifications").upsert(
-          {
+      // Step 2: find users who saved those events
+      const { data: saved24h } = await supabase
+        .from("saved_events")
+        .select("user_id, event_id")
+        .in("event_id", eventIds24h);
+
+      if (saved24h && saved24h.length > 0) {
+        // Batch-fetch already-logged 24h reminders (mirrors a LEFT JOIN ... IS NULL check)
+        const { data: logged24h } = await supabase
+          .from("email_reminder_log")
+          .select("user_id, event_id")
+          .eq("reminder_type", "reminder_24h")
+          .in("event_id", eventIds24h);
+
+        const sent24hSet = new Set(
+          (logged24h ?? []).map((r) => `${r.user_id}:${r.event_id}`)
+        );
+
+        for (const row of saved24h) {
+          const event = events24h.find((e) => e.id === row.event_id);
+          if (!event) continue;
+
+          // Skip — already sent during a previous cron run
+          if (sent24hSet.has(`${row.user_id}:${event.id}`)) {
+            remindersSkipped["24h"]++;
+            continue;
+          }
+
+          const { error: notifErr } = await supabase.from("notifications").insert({
             user_id: row.user_id,
             event_id: event.id,
             type: "event_reminder_24h",
             title: "Event Tomorrow",
             message: `"${event.title}" starts in about 24 hours.`,
-          },
-          { onConflict: "user_id,event_id,type", ignoreDuplicates: true }
-        );
-        if (!err24h) remindersSent["24h"]++;
+          });
+
+          // null = fresh insert; 23505 = notification already existed (orphaned prior send)
+          if (!notifErr || notifErr.code === "23505") {
+            // Record the send so re-runs stay silent
+            await supabase.from("email_reminder_log").insert({
+              user_id: row.user_id,
+              event_id: event.id,
+              reminder_type: "reminder_24h",
+            });
+            remindersSent["24h"]++;
+          }
+        }
       }
     }
 
-    // 1-hour reminders: events starting between now+55min and now+65min
+    // ── 1-hour reminders ───────────────────────────────────────────────────
     const h1Start = new Date(now.getTime() + 55 * 60 * 1000).toISOString();
-    const h1End = new Date(now.getTime() + 65 * 60 * 1000).toISOString();
+    const h1End   = new Date(now.getTime() + 65 * 60 * 1000).toISOString();
 
-    const { data: saved1h } = await supabase
-      .from("saved_events")
-      .select("user_id, event_id, events:event_id(id, title, start_date)")
-      .gte("events.start_date", h1Start)
-      .lte("events.start_date", h1End);
+    // Step 1: find events in the 1h window
+    const { data: events1h } = await supabase
+      .from("events")
+      .select("id, title, start_date")
+      .gte("start_date", h1Start)
+      .lte("start_date", h1End);
 
-    if (saved1h) {
-      for (const row of saved1h) {
-        const event = row.events as unknown as { id: string; title: string; start_date: string } | null;
-        if (!event) continue;
+    if (events1h && events1h.length > 0) {
+      const eventIds1h = events1h.map((e) => e.id);
 
-        const { error: err1h } = await supabase.from("notifications").upsert(
-          {
+      // Step 2: find users who saved those events
+      const { data: saved1h } = await supabase
+        .from("saved_events")
+        .select("user_id, event_id")
+        .in("event_id", eventIds1h);
+
+      if (saved1h && saved1h.length > 0) {
+        // Batch-fetch already-logged 1h reminders
+        const { data: logged1h } = await supabase
+          .from("email_reminder_log")
+          .select("user_id, event_id")
+          .eq("reminder_type", "reminder_1h")
+          .in("event_id", eventIds1h);
+
+        const sent1hSet = new Set(
+          (logged1h ?? []).map((r) => `${r.user_id}:${r.event_id}`)
+        );
+
+        for (const row of saved1h) {
+          const event = events1h.find((e) => e.id === row.event_id);
+          if (!event) continue;
+
+          // Skip — already sent during a previous cron run
+          if (sent1hSet.has(`${row.user_id}:${event.id}`)) {
+            remindersSkipped["1h"]++;
+            continue;
+          }
+
+          const { error: notifErr } = await supabase.from("notifications").insert({
             user_id: row.user_id,
             event_id: event.id,
             type: "event_reminder_1h",
             title: "Event Starting Soon",
             message: `"${event.title}" starts in about 1 hour!`,
-          },
-          { onConflict: "user_id,event_id,type", ignoreDuplicates: true }
-        );
-        if (!err1h) remindersSent["1h"]++;
+          });
+
+          // null = fresh insert; 23505 = notification already existed (orphaned prior send)
+          if (!notifErr || notifErr.code === "23505") {
+            // Record the send so re-runs stay silent
+            await supabase.from("email_reminder_log").insert({
+              user_id: row.user_id,
+              event_id: event.id,
+              reminder_type: "reminder_1h",
+            });
+            remindersSent["1h"]++;
+          }
+        }
       }
     }
 
     return NextResponse.json({
       success: true,
       reminders_sent: remindersSent,
+      reminders_skipped: remindersSkipped,
       checked_at: now.toISOString(),
     });
   } catch (err) {

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -626,6 +626,30 @@ export interface Database {
         };
         Relationships: [];
       };
+      email_reminder_log: {
+        Row: {
+          id: string;
+          user_id: string;
+          event_id: string;
+          reminder_type: "reminder_24h" | "reminder_1h";
+          sent_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          event_id: string;
+          reminder_type: "reminder_24h" | "reminder_1h";
+          sent_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          event_id?: string;
+          reminder_type?: "reminder_24h" | "reminder_1h";
+          sent_at?: string;
+        };
+        Relationships: [];
+      };
     };
     Views: {
       [_ in never]: never;

--- a/supabase/migrations/20260305000002_email_reminder_log.sql
+++ b/supabase/migrations/20260305000002_email_reminder_log.sql
@@ -1,0 +1,33 @@
+-- Migration: email_reminder_log
+-- Prevents duplicate reminder notifications when the cron misfires or runs twice.
+-- The UNIQUE constraint on (user_id, event_id, reminder_type) is the hard guard;
+-- the cron also does a pre-send lookup to skip already-logged rows.
+
+CREATE TABLE email_reminder_log (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID        REFERENCES auth.users(id) ON DELETE CASCADE,
+  event_id      UUID        REFERENCES events(id) ON DELETE CASCADE,
+  reminder_type TEXT        NOT NULL CHECK (reminder_type IN ('reminder_24h', 'reminder_1h')),
+  sent_at       TIMESTAMPTZ DEFAULT now() NOT NULL,
+  UNIQUE (user_id, event_id, reminder_type)
+);
+
+-- Index to speed up the pre-send dedup lookup (filter by reminder_type + event_id)
+CREATE INDEX email_reminder_log_type_event_idx
+  ON email_reminder_log (reminder_type, event_id);
+
+-- RLS: internal log — service role handles all writes (bypasses RLS).
+-- Users can only read their own entries; no direct write access.
+ALTER TABLE email_reminder_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own reminder log"
+  ON email_reminder_log
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Service role can manage reminder log"
+  ON email_reminder_log
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
Email Reminder Idempotency — Implementation Report
Problem
The cron job at POST /api/cron/send-reminders had no deduplication mechanism. A misfire or double-run would insert duplicate notifications for users.

What Was Done
1. Migration — supabase/migrations/20260305000002_email_reminder_log.sql

Created the email_reminder_log table as a persistent record of every reminder sent. The UNIQUE(user_id, event_id, reminder_type) constraint acts as a hard backstop against duplicates at the database level.

2. TypeScript types — src/lib/supabase/types.ts

Added email_reminder_log to the Database type so the Supabase client is fully typed against the new table.

3. Cron route — src/app/api/cron/send-reminders/route.ts

Rewrote the query strategy and added dedup logic:

Query fix: switched from a single embedded-relation query (which PostgREST filtered incorrectly) to a two-step approach — query events for the time window, then saved_events for those event IDs
Pre-send check: batch-fetches email_reminder_log before the loop and builds a Set; any user:event pair already logged is skipped
Post-send log: inserts into email_reminder_log after each successful notification insert
Notification insert: replaced upsert with insert, treating 23505 (unique violation) as success — necessary because PostgREST cannot target partial unique indexes via onConflict
Response: added reminders_skipped to the response alongside reminders_sent